### PR TITLE
Feature: Toggle Item Restriction based on Container Type

### DIFF
--- a/DynamicStoragePiles/DynamicStoragePiles.cs
+++ b/DynamicStoragePiles/DynamicStoragePiles.cs
@@ -79,10 +79,6 @@ namespace DynamicStoragePiles {
             if (Chainloader.PluginInfos.ContainsKey("Richard.IngotStacks")) {
                 Compatibility.IngotStacks.Init();
             }
-
-            // All containers have been created and their restrictions set in allowedItemsByContainer
-            // so RestrictContainers can be initialized to enforce those restrictions.
-            RestrictContainers.SetContainerRestrictions(allowedItemsByContainer);
         }
 
         private static void DisablePieceRecipes(bool forceUpdate) {

--- a/DynamicStoragePiles/DynamicStoragePiles.cs
+++ b/DynamicStoragePiles/DynamicStoragePiles.cs
@@ -31,6 +31,8 @@ namespace DynamicStoragePiles {
         public static ConfigEntry<bool> azuAutoStoreItemWhitelist;
         public static ConfigEntry<bool> ingotStacksDisableRecipes;
         public static ConfigEntry<bool> ingotStacksDisableAdditionalStackRecipes;
+        public static ConfigEntry<bool> restrictDynamicPiles;
+        public static bool ShouldRestrictItems => restrictDynamicPiles.Value;
 
         private void Awake() {
             Instance = this;
@@ -47,6 +49,8 @@ namespace DynamicStoragePiles {
 
             disableVanillaRecipes = Config.Bind("1 - General", "Disable Vanilla Stack Recipes", false, "Prevents vanilla stack pieces from being placeable with the hammer. It uses the vanilla system to disable pieces, cheats or world modifiers can overwrite this setting. Existing pieces in the world are not affected");
             disableVanillaRecipes.SettingChanged += (sender, args) => DisablePieceRecipes(true);
+
+            restrictDynamicPiles = Config.Bind("1 - General", "Restrict Container Item Type", true, "Prevents items other than the one the dynamic storage container represents from being placed in it");
 
             azuAutoStoreCompat = Config.Bind("2 - Compatibility", "AzuAutoStore Compatibility", true, "Enables compatibility with AzuAutoStore. Requires a restart to take effect");
             azuAutoStoreItemWhitelist = Config.Bind("2 - Compatibility", "AzuAutoStore Item Whitelist", true, "Only allows the respective items to be stored in stack piles");

--- a/DynamicStoragePiles/DynamicStoragePiles.cs
+++ b/DynamicStoragePiles/DynamicStoragePiles.cs
@@ -34,6 +34,9 @@ namespace DynamicStoragePiles {
         public static ConfigEntry<bool> restrictDynamicPiles;
         public static bool ShouldRestrictItems => restrictDynamicPiles.Value;
 
+        private static readonly Dictionary<string, string> allowedItemsByContainer = new Dictionary<string, string>();
+        
+
         private void Awake() {
             Instance = this;
             assetBundle = AssetUtils.LoadAssetBundleFromResources("containerstacks");
@@ -76,6 +79,10 @@ namespace DynamicStoragePiles {
             if (Chainloader.PluginInfos.ContainsKey("Richard.IngotStacks")) {
                 Compatibility.IngotStacks.Init();
             }
+
+            // All containers have been created and their restrictions set in allowedItemsByContainer
+            // so RestrictContainers can be initialized to enforce those restrictions.
+            RestrictContainers.SetContainerRestrictions(allowedItemsByContainer);
         }
 
         private static void DisablePieceRecipes(bool forceUpdate) {
@@ -128,6 +135,7 @@ namespace DynamicStoragePiles {
             PieceManager.Instance.AddPiece(piece);
             pieces.Add(piece);
             allowedItemsByStack.Add(pieceName, craftItem);
+            allowedItemsByContainer.Add(piece.PiecePrefab.GetComponent<Container>().m_name, craftItem);
         }
 
         public void AddPiece(GameObject prefab, string craftItem, int amount) {
@@ -135,6 +143,7 @@ namespace DynamicStoragePiles {
             PieceManager.Instance.AddPiece(piece);
             pieces.Add(piece);
             allowedItemsByStack.Add(prefab.name, craftItem);
+            allowedItemsByContainer.Add(prefab.GetComponent<Container>().m_name, craftItem);
         }
 
         private void OnPiecesRegistered() {

--- a/DynamicStoragePiles/DynamicStoragePiles.cs
+++ b/DynamicStoragePiles/DynamicStoragePiles.cs
@@ -34,7 +34,7 @@ namespace DynamicStoragePiles {
         public static ConfigEntry<bool> restrictDynamicPiles;
         public static bool ShouldRestrictItems => restrictDynamicPiles.Value;
 
-        private static readonly Dictionary<string, string> allowedItemsByContainer = new Dictionary<string, string>();
+        public static readonly Dictionary<string, string> allowedItemsByContainer = new Dictionary<string, string>();
         
 
         private void Awake() {

--- a/DynamicStoragePiles/DynamicStoragePiles.csproj
+++ b/DynamicStoragePiles/DynamicStoragePiles.csproj
@@ -113,6 +113,7 @@
   <Target Name="Deploy">
     <Message Text="Deploing into: $(FULL_DEPLOY_FOLDER)" Importance="high" />
     <MakeDir Directories="$(FULL_DEPLOY_FOLDER)" />
+	  
     <!--Create Thunderstore Zip-->
     <RemoveDir Directories="$(TMP_DEPLOY_FOLDER)" />
     <Copy SourceFiles="$(TargetDir)$(TargetName).dll" DestinationFolder="$(TMP_DEPLOY_FOLDER)" />
@@ -120,10 +121,12 @@
     <Copy SourceFiles="$(SolutionDir)README.md" DestinationFolder="$(TMP_DEPLOY_FOLDER)" />
     <Copy SourceFiles="$(SolutionDir)Package/manifest.json" DestinationFolder="$(TMP_DEPLOY_FOLDER)" />
     <ZipDirectory SourceDirectory="$(TMP_DEPLOY_FOLDER)" DestinationFile="$(FULL_DEPLOY_FOLDER)/$(TargetName).zip" Overwrite="true" />
+	  
     <!--Create Nexus Zip-->
     <RemoveDir Directories="$(TMP_DEPLOY_FOLDER)" />
     <Copy SourceFiles="$(TargetDir)$(TargetName).dll" DestinationFolder="$(TMP_DEPLOY_FOLDER)/plugins/$(TargetName)" />
     <ZipDirectory SourceDirectory="$(TMP_DEPLOY_FOLDER)" DestinationFile="$(FULL_DEPLOY_FOLDER)/$(TargetName)-Nexus.zip" Overwrite="true" />
+	  
     <!--Unpack to deploy folder-->
     <Unzip Condition="Exists('$(DEPLOY_FOLDER)')" SourceFiles="$(FULL_DEPLOY_FOLDER)/$(TargetName).zip" DestinationFolder="$(FULL_DEPLOY_FOLDER)" />
     <Unzip Condition="Exists('$(DEPLOY_FOLDER_XBOX)')" SourceFiles="$(FULL_DEPLOY_FOLDER)/$(TargetName).zip" DestinationFolder="$(FULL_DEPLOY_FOLDER_XBOX)" />

--- a/DynamicStoragePiles/DynamicStoragePiles.csproj
+++ b/DynamicStoragePiles/DynamicStoragePiles.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Properties\IgnoreAccessModifiers.cs" />
     <Compile Include="DynamicStoragePiles.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RestrictContainers.cs" />
     <Compile Include="VisualStack.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -112,7 +113,6 @@
   <Target Name="Deploy">
     <Message Text="Deploing into: $(FULL_DEPLOY_FOLDER)" Importance="high" />
     <MakeDir Directories="$(FULL_DEPLOY_FOLDER)" />
-
     <!--Create Thunderstore Zip-->
     <RemoveDir Directories="$(TMP_DEPLOY_FOLDER)" />
     <Copy SourceFiles="$(TargetDir)$(TargetName).dll" DestinationFolder="$(TMP_DEPLOY_FOLDER)" />
@@ -120,12 +120,10 @@
     <Copy SourceFiles="$(SolutionDir)README.md" DestinationFolder="$(TMP_DEPLOY_FOLDER)" />
     <Copy SourceFiles="$(SolutionDir)Package/manifest.json" DestinationFolder="$(TMP_DEPLOY_FOLDER)" />
     <ZipDirectory SourceDirectory="$(TMP_DEPLOY_FOLDER)" DestinationFile="$(FULL_DEPLOY_FOLDER)/$(TargetName).zip" Overwrite="true" />
-
     <!--Create Nexus Zip-->
     <RemoveDir Directories="$(TMP_DEPLOY_FOLDER)" />
     <Copy SourceFiles="$(TargetDir)$(TargetName).dll" DestinationFolder="$(TMP_DEPLOY_FOLDER)/plugins/$(TargetName)" />
     <ZipDirectory SourceDirectory="$(TMP_DEPLOY_FOLDER)" DestinationFile="$(FULL_DEPLOY_FOLDER)/$(TargetName)-Nexus.zip" Overwrite="true" />
-
     <!--Unpack to deploy folder-->
     <Unzip Condition="Exists('$(DEPLOY_FOLDER)')" SourceFiles="$(FULL_DEPLOY_FOLDER)/$(TargetName).zip" DestinationFolder="$(FULL_DEPLOY_FOLDER)" />
     <Unzip Condition="Exists('$(DEPLOY_FOLDER_XBOX)')" SourceFiles="$(FULL_DEPLOY_FOLDER)/$(TargetName).zip" DestinationFolder="$(FULL_DEPLOY_FOLDER_XBOX)" />

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -121,33 +121,10 @@ namespace DynamicStoragePiles {
         /// <param name="item"></param>
         /// <returns></returns>
         [HarmonyPrefix]
-        [HarmonyPatch(nameof(Inventory.MoveItemToThis), new[] { typeof(Inventory), typeof(ItemDrop.ItemData) })]
-        [HarmonyPriority(Priority.First)]
-        private static bool MoveItemToThisPrefix_1(Inventory __instance, Inventory fromInventory, ItemDrop.ItemData item) {
-            if (__instance == null || fromInventory == null || item == null) { return false; }
-
-            Jotunn.Logger.LogDebug("MoveItemToThisPrefix");
-            Jotunn.Logger.LogDebug($"Add to: {__instance.m_name}");
-            Jotunn.Logger.LogDebug($"Item: {item.PrefabName()}");
-            
-            return CanAddItem(__instance, item);
-        }
-
-
-        /// <summary>
-        ///     Patch to prevent MoveItemToThis from running if CanAddItem check is false. MoveItemToThis
-        ///     will call RemoveItem from the source inventory even in cases where AddItem returns false,
-        ///     so the entire method needs to be prevented from running to avoid items being lost when players
-        ///     try to place items in containers that do not allow that type of item.
-        /// </summary>
-        /// <param name="__instance"></param>
-        /// <param name="fromInventory"></param>
-        /// <param name="item"></param>
-        /// <returns></returns>
-        [HarmonyPrefix]
+        [HarmonyPatch(typeof(Inventory), nameof(Inventory.MoveItemToThis), new[] { typeof(Inventory), typeof(ItemDrop.ItemData) })]
         [HarmonyPatch(typeof(Inventory), nameof(Inventory.MoveItemToThis), new[] { typeof(Inventory), typeof(ItemDrop.ItemData), typeof(int), typeof(int), typeof(int) })]
         [HarmonyPriority(Priority.First)]
-        private static bool MoveItemToThisPrefix_2(Inventory __instance, Inventory fromInventory, ItemDrop.ItemData item, int amount) {
+        private static bool MoveItemToThisPrefix(Inventory __instance, Inventory fromInventory, ItemDrop.ItemData item) {
             if (__instance == null || fromInventory == null || item == null) { return false; }
 
             Jotunn.Logger.LogDebug("MoveItemToThisPrefix");

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using HarmonyLib;
+﻿using HarmonyLib;
 
 namespace DynamicStoragePiles {
 

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -14,6 +14,33 @@ namespace DynamicStoragePiles {
 
 
         /// <summary>
+        ///     Checks if the item being dropped into the inventory is allowed to be placed in it and checks
+        ///     if the item that would be swapped into the fromInventory is allowed to be placed in it.
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="fromInventory"></param>
+        /// <param name="item"></param>
+        /// <param name="pos"></param>
+        /// <returns></returns>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(InventoryGrid), nameof(InventoryGrid.DropItem))]
+        private static bool DropItemPrefix(InventoryGrid __instance, Inventory fromInventory, ItemDrop.ItemData item, Vector2i pos) {
+
+            // Return early if item can't be dropped into inventory
+            if (!CanAddItem(__instance.m_inventory, item)) {
+                return false;
+            }
+
+            // Check if item being swapped can be placed in fromInventory
+            ItemDrop.ItemData itemAt = __instance.m_inventory.GetItemAt(pos.x, pos.y);
+            if (itemAt != null) {
+                return CanAddItem(fromInventory, itemAt);
+            }
+
+            return true;
+        }
+
+        /// <summary>
         ///     Checks if adding item to inventory should be blocked based on
         ///     if the container and item names are restricted. Also notifies
         ///     the player of why adding the item is not allowed.

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -1,0 +1,298 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DynamicStoragePiles {
+
+    /// <summary>
+    ///     Class to patch Valheim inventory methods so that the specified
+    ///     containers can only contain items of a single type.
+    /// </summary>
+    [HarmonyPatch(typeof(Inventory))]
+    internal static class RestrictContainers {
+        private static string _loadingContainer;
+        private static string _targetContainer;
+        private static string _allowedItem;
+        private static Dictionary<string, string> _allowedItemsByContainer = new Dictionary<string, string>();
+
+        /// <summary>
+        ///     Set which containers to restrict and which item is allowed to be placed in each one.
+        /// </summary>
+        /// <param name="allowedItemByContainer"></param>
+        public static void SetContainerRestrictions(Dictionary<string, string> allowedItemByContainer) {
+            _allowedItemsByContainer = allowedItemByContainer;
+        }
+
+        /// <summary>
+        ///     Checks if adding item to inventory should be blocked based on
+        ///     if the container and item names are restricted. Also notifies
+        ///     the player of why adding the item is not allowed.
+        /// </summary>
+        /// <param name="inventory"></param>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        private static bool CanAddItem(Inventory inventory, ItemDrop.ItemData item) {
+            if (inventory == null || item == null) { return false; }
+            Jotunn.Logger.LogDebug("CanAddItem");
+            Jotunn.Logger.LogDebug($"Add to: {inventory.m_name}");
+            Jotunn.Logger.LogDebug($"Item: {item.PrefabName()}");
+
+            // Return early if this check is being called while loading a container.
+            // Don't want to delete "non-allowed" items that were put in the container
+            // while the restrictions were disabled.
+            if (!string.IsNullOrEmpty(_loadingContainer) && inventory.m_name == _loadingContainer) {
+                return true;
+            }
+
+            if (IsRestrictedContainer(inventory.m_name, out string allowedItem))
+            {
+                var result = item.PrefabName() == allowedItem;
+                if (!result) {
+                    // Message player that item cannot be placed in container.
+                    var msg = $"{item.m_shared.m_name} cannnot be placed in {inventory.m_name}";
+                    Player.m_localPlayer?.Message(MessageHud.MessageType.Center, msg);
+                }
+                return result;
+            }
+            return true;
+        }
+
+        /// <summary>
+        ///     Check if container should be restricted and get the allowed item type for it
+        /// </summary>
+        /// <param name="containerName"></param>
+        /// <param name="allowedItem"></param>
+        /// <returns></returns>
+        public static bool IsRestrictedContainer(string containerName, out string allowedItem) {
+            if (!DynamicStoragePiles.ShouldRestrictItems) {
+                allowedItem = null;
+                return false;
+            }
+            return _allowedItemsByContainer.TryGetValue(containerName, out allowedItem);
+        }
+
+        /// <summary>
+        ///    Patch to trigger CanAddItem check when attempting to add item to inventory.
+        ///    If CanAddItem is false then the AddItem method in Valheim will be skipped
+        ///    and return false to indicate the item was not added.
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="item"></param>
+        /// <param name="__result"></param>
+        /// <returns></returns>
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(Inventory.AddItem), new[] { typeof(ItemDrop.ItemData) })]
+        [HarmonyPriority(Priority.First)]
+        private static bool AddItemPrefix_1(Inventory __instance, ItemDrop.ItemData item, ref bool __result) {
+            if (!CanAddItem(__instance, item)) {
+                __result = false;
+                return __result;
+            }
+            return true;
+        }
+
+        /// <summary>
+        ///    Patch to trigger CanAddItem check when attempting to add item to inventory.
+        ///    If CanAddItem is false then the AddItem method in Valheim will be skipped
+        ///    and return false to indicate the item was not added.
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="item"></param>
+        /// <param name="__result"></param>
+        /// <returns></returns>
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(Inventory.AddItem), new[] { typeof(ItemDrop.ItemData), typeof(int), typeof(int), typeof(int) })]
+        [HarmonyPriority(Priority.First)]
+        private static bool AddItemPrefix_2(Inventory __instance, ItemDrop.ItemData item, ref bool __result) {
+            if (!CanAddItem(__instance, item)) {
+                __result = false;
+                return __result;
+            }
+            return true;
+        }
+
+        /// <summary>
+        ///     Patch to prevent MoveItemToThis from running if CanAddItem check is false. MoveItemToThis
+        ///     will call RemoveItem from the source inventory even in cases where AddItem returns false,
+        ///     so the entire method needs to be prevented from running to avoid items being lost when players
+        ///     try to place items in containers that do not allow that type of item.
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="fromInventory"></param>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(Inventory.MoveItemToThis), new[] { typeof(Inventory), typeof(ItemDrop.ItemData) })]
+        [HarmonyPriority(Priority.First)]
+        private static bool MoveItemToThisPrefix_1(Inventory __instance, Inventory fromInventory, ItemDrop.ItemData item) {
+            if (__instance == null || fromInventory == null || item == null) { return false; }
+            Jotunn.Logger.LogDebug("MoveItemToThisPrefix");
+            Jotunn.Logger.LogDebug($"Add to: {__instance.m_name}");
+            Jotunn.Logger.LogDebug($"Item: {item.PrefabName()}");
+            return CanAddItem(__instance, item);
+        }
+
+
+        /// <summary>
+        ///     Patch to prevent MoveItemToThis from running if CanAddItem check is false. MoveItemToThis
+        ///     will call RemoveItem from the source inventory even in cases where AddItem returns false,
+        ///     so the entire method needs to be prevented from running to avoid items being lost when players
+        ///     try to place items in containers that do not allow that type of item.
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="fromInventory"></param>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(Inventory), nameof(Inventory.MoveItemToThis), new[] { typeof(Inventory), typeof(ItemDrop.ItemData), typeof(int), typeof(int), typeof(int) })]
+        [HarmonyPriority(Priority.First)]
+        private static bool MoveItemToThisPrefix_2(Inventory __instance, Inventory fromInventory, ItemDrop.ItemData item) {
+            if (__instance == null || fromInventory == null || item == null) { return false; }
+
+            Jotunn.Logger.LogDebug("MoveItemToThisPrefix");
+            Jotunn.Logger.LogDebug($"Add to: {__instance.m_name}");
+            Jotunn.Logger.LogDebug($"Item: {item.PrefabName()}");
+            
+            return CanAddItem(__instance, item);
+        }
+
+        // Dev Note: I don't actually think the MoveAll and RemoveItem patches are necessary
+        // but I've kept them just in case IronGate decides to change MoveAll to function
+        // like MoveToThis or other mods do stuff during MoveAll.
+
+        /// <summary>
+        ///     Patch to check if MoveAll is being used to dump inventory into a restricted
+        ///     container and record the container name and allowed item type if it is so that
+        ///     removal of items from the source inventory can be prevented if they were not added to the container.
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="fromInventory"></param>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(Inventory), nameof(Inventory.MoveAll), new[] { typeof(Inventory) })]
+        [HarmonyPriority(Priority.First)]
+        private static void MoveAllPrefix(Inventory __instance, Inventory fromInventory) {
+            if (__instance == null || fromInventory == null) { return; }
+            
+            Jotunn.Logger.LogDebug("MoveAllPrefix");
+            Jotunn.Logger.LogDebug($"Move to: {__instance.m_name}");
+
+            if (IsRestrictedContainer(__instance.m_name, out string allowedItem)) {
+                _targetContainer = __instance.m_name;
+                _allowedItem = allowedItem;
+            }
+        }
+
+        /// <summary>
+        ///     Reset the _targetContainer and _allowedItem values since MoveAll has finished.
+        /// </summary>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(Inventory), nameof(Inventory.MoveAll), new[] { typeof(Inventory) })]
+        [HarmonyPriority(Priority.First)]
+        private static void MoveAllPostfix() {
+            _targetContainer = null;
+            _allowedItem = null;
+        }
+
+        /// <summary>
+        ///     Patch to check trigger ShouldRemoveItem check and prevent RemoveItem from running if
+        ///     the item was moved during a call to MoveAll and failed to be added to the target
+        ///     container because it was restricted and not the allowed item type.
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(Inventory), nameof(Inventory.RemoveItem), new[] { typeof(ItemDrop.ItemData) })]
+        [HarmonyPriority(Priority.First)]
+        private static bool RemoveItemPrefix_1(Inventory __instance, ItemDrop.ItemData item) {
+            return ShouldRemoveItem(__instance, item);
+        }
+
+        /// <summary>
+        ///     Patch to check trigger ShouldRemoveItem check and prevent RemoveItem from running if
+        ///     the item was moved during a call to MoveAll and failed to be added to the target
+        ///     container because it was restricted and not the allowed item type.
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(Inventory.RemoveItem), new[] { typeof(ItemDrop.ItemData), typeof(int) })]
+        [HarmonyPriority(Priority.First)]
+        private static bool RemoveItemPrefix_2(Inventory __instance, ItemDrop.ItemData item) {
+            return ShouldRemoveItem(__instance, item);
+        }
+
+        /// <summary>
+        ///     Patch to check trigger ShouldRemoveItem check and prevent RemoveItem from running if
+        ///     the item was moved during a call to MoveAll and failed to be added to the target
+        ///     container because it was restricted and not the allowed item type.
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(Inventory.RemoveOneItem), new[] { typeof(ItemDrop.ItemData) })]
+        [HarmonyPriority(Priority.First)]
+        private static bool RemoveOneItemPrefix(Inventory __instance, ItemDrop.ItemData item) {
+            return ShouldRemoveItem(__instance, item);
+        }
+
+        /// <summary>
+        ///    Checks if the values for _targetContainer and _allowedItem were set during a
+        ///    call to MoveAll and checks it the item matches _allowableItem and therefore
+        ///    should be removed since it was added to _targetContainerr
+        /// </summary>
+        /// <param name="__instance"></param>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        private static bool ShouldRemoveItem(Inventory __instance, ItemDrop.ItemData item) {
+            // early return and block removal since it's null
+            if (__instance == null || item == null)
+            {
+                return false;
+            }
+
+            // Check if item is being removed because it was moved to a dynamic container
+            bool wasAddedToDynamicPile = !string.IsNullOrEmpty(_targetContainer);
+            bool haveAllowableItem = !string.IsNullOrEmpty(_allowedItem);
+
+            Jotunn.Logger.LogDebug("RemoveItemPrefix");
+            Jotunn.Logger.LogDebug($"Remove from: {__instance.m_name}");
+            Jotunn.Logger.LogDebug($"Item: {item.PrefabName()}");
+
+            if (wasAddedToDynamicPile && haveAllowableItem) {
+                return item.PrefabName() != _allowedItem;
+            }
+            return true;
+        }
+
+        /// <summary>
+        ///     Patch to allow checking if the Container is being loaded
+        ///     from ZDO rather than altered by interacting in-game. Used
+        ///     to avoid restricted items being loaded and prevent deleting
+        ///     "non-allowed" items that had been put in the container when
+        ///     restrictions were not enabled.
+        /// </summary>
+        /// <param name="__instance"></param>
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(Inventory.Load))]
+        private static void LoadPrefix(Inventory __instance) {
+            if (__instance == null) { return; }
+            Jotunn.Logger.LogDebug($"Load prefix: {__instance.m_name}");
+            _loadingContainer = __instance.m_name;
+        }
+
+        /// <summary>
+        ///     Reset value for _loadingContainer so that restrictions are applied correctly.
+        /// </summary>
+        /// <param name="__instance"></param>
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(Inventory.Load))]
+        private static void LoadPostfix() {
+            _loadingContainer = null;
+        }
+    }
+}

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -88,6 +88,7 @@ namespace DynamicStoragePiles {
                 allowedItem = null;
                 return false;
             }
+
             return DynamicStoragePiles.allowedItemsByContainer.TryGetValue(containerName, out allowedItem);
         }
 
@@ -127,7 +128,9 @@ namespace DynamicStoragePiles {
         [HarmonyPatch(typeof(Inventory), nameof(Inventory.MoveItemToThis), new[] { typeof(Inventory), typeof(ItemDrop.ItemData), typeof(int), typeof(int), typeof(int) })]
         [HarmonyPriority(Priority.First)]
         private static bool MoveItemToThisPrefix(Inventory __instance, Inventory fromInventory, ItemDrop.ItemData item) {
-            if (__instance == null || fromInventory == null || item == null) { return false; }
+            if (__instance == null || fromInventory == null || item == null) {
+                return false;
+            }
 
             Jotunn.Logger.LogDebug("MoveItemToThisPrefix");
             Jotunn.Logger.LogDebug($"Add to: {__instance.m_name}");
@@ -231,6 +234,7 @@ namespace DynamicStoragePiles {
             if (wasAddedToDynamicPile && haveAllowableItem) {
                 return item.PrefabName() != _allowedItem;
             }
+
             return true;
         }
 
@@ -245,7 +249,9 @@ namespace DynamicStoragePiles {
         [HarmonyPrefix]
         [HarmonyPatch(typeof(Inventory), nameof(Inventory.Load))]
         private static void LoadPrefix(Inventory __instance) {
-            if (__instance == null) { return; }
+            if (__instance == null) {
+                return;
+            }
 
             Jotunn.Logger.LogDebug($"Load prefix: {__instance.m_name}");
 

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -12,15 +12,7 @@ namespace DynamicStoragePiles {
         private static string _loadingContainer;
         private static string _targetContainer;
         private static string _allowedItem;
-        private static Dictionary<string, string> _allowedItemsByContainer = new Dictionary<string, string>();
 
-        /// <summary>
-        ///     Set which containers to restrict and which item is allowed to be placed in each one.
-        /// </summary>
-        /// <param name="allowedItemByContainer"></param>
-        public static void SetContainerRestrictions(Dictionary<string, string> allowedItemByContainer) {
-            _allowedItemsByContainer = allowedItemByContainer;
-        }
 
         /// <summary>
         ///     Checks if adding item to inventory should be blocked based on
@@ -67,7 +59,7 @@ namespace DynamicStoragePiles {
                 allowedItem = null;
                 return false;
             }
-            return _allowedItemsByContainer.TryGetValue(containerName, out allowedItem);
+            return DynamicStoragePiles.allowedItemsByContainer.TryGetValue(containerName, out allowedItem);
         }
 
         /// <summary>

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -53,10 +53,6 @@ namespace DynamicStoragePiles {
                 return false;
             }
 
-            Jotunn.Logger.LogDebug("CanAddItem");
-            Jotunn.Logger.LogDebug($"Add to: {inventory.m_name}");
-            Jotunn.Logger.LogDebug($"Item: {item.PrefabName()}");
-
             // Return early if this check is being called while loading a container.
             // Don't want to delete "non-allowed" items that were put in the container
             // while the restrictions were disabled.
@@ -110,6 +106,7 @@ namespace DynamicStoragePiles {
                 __result = false;
                 return __result;
             }
+
             return true;
         }
 
@@ -132,10 +129,6 @@ namespace DynamicStoragePiles {
                 return false;
             }
 
-            Jotunn.Logger.LogDebug("MoveItemToThisPrefix");
-            Jotunn.Logger.LogDebug($"Add to: {__instance.m_name}");
-            Jotunn.Logger.LogDebug($"Item: {item.PrefabName()}");
-
             return CanAddItem(__instance, item);
         }
 
@@ -157,9 +150,6 @@ namespace DynamicStoragePiles {
             if (__instance == null || fromInventory == null) {
                 return;
             }
-
-            Jotunn.Logger.LogDebug("MoveAllPrefix");
-            Jotunn.Logger.LogDebug($"Move to: {__instance.m_name}");
 
             if (IsRestrictedContainer(__instance.m_name, out string allowedItem)) {
                 _targetContainer = __instance.m_name;
@@ -227,10 +217,6 @@ namespace DynamicStoragePiles {
             bool wasAddedToDynamicPile = !string.IsNullOrEmpty(_targetContainer);
             bool haveAllowableItem = !string.IsNullOrEmpty(_allowedItem);
 
-            Jotunn.Logger.LogDebug("RemoveItemPrefix");
-            Jotunn.Logger.LogDebug($"Remove from: {__instance.m_name}");
-            Jotunn.Logger.LogDebug($"Item: {item.PrefabName()}");
-
             if (wasAddedToDynamicPile && haveAllowableItem) {
                 return item.PrefabName() != _allowedItem;
             }
@@ -252,8 +238,6 @@ namespace DynamicStoragePiles {
             if (__instance == null) {
                 return;
             }
-
-            Jotunn.Logger.LogDebug($"Load prefix: {__instance.m_name}");
 
             _loadingContainer = __instance.m_name;
         }

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -81,28 +81,9 @@ namespace DynamicStoragePiles {
         /// <returns></returns>
         [HarmonyPrefix]
         [HarmonyPatch(nameof(Inventory.AddItem), new[] { typeof(ItemDrop.ItemData) })]
-        [HarmonyPriority(Priority.First)]
-        private static bool AddItemPrefix_1(Inventory __instance, ItemDrop.ItemData item, ref bool __result) {
-            if (!CanAddItem(__instance, item)) {
-                __result = false;
-                return __result;
-            }
-            return true;
-        }
-
-        /// <summary>
-        ///    Patch to trigger CanAddItem check when attempting to add item to inventory.
-        ///    If CanAddItem is false then the AddItem method in Valheim will be skipped
-        ///    and return false to indicate the item was not added.
-        /// </summary>
-        /// <param name="__instance"></param>
-        /// <param name="item"></param>
-        /// <param name="__result"></param>
-        /// <returns></returns>
-        [HarmonyPrefix]
         [HarmonyPatch(nameof(Inventory.AddItem), new[] { typeof(ItemDrop.ItemData), typeof(int), typeof(int), typeof(int) })]
         [HarmonyPriority(Priority.First)]
-        private static bool AddItemPrefix_2(Inventory __instance, ItemDrop.ItemData item, int amount, ref bool __result) {
+        private static bool AddItemPrefix(Inventory __instance, ItemDrop.ItemData item, ref bool __result) {
             if (!CanAddItem(__instance, item)) {
                 __result = false;
                 return __result;

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -8,7 +8,7 @@ namespace DynamicStoragePiles
     ///     Class to patch Valheim inventory methods so that the specified
     ///     containers can only contain items of a single type.
     /// </summary>
-    [HarmonyPatch(typeof(Inventory))]
+    [HarmonyPatch]
     internal static class RestrictContainers
     {
         private static string _loadingContainer;

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using HarmonyLib;
 
 namespace DynamicStoragePiles {
 

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -162,23 +162,9 @@ namespace DynamicStoragePiles {
         /// <returns></returns>
         [HarmonyPrefix]
         [HarmonyPatch(typeof(Inventory), nameof(Inventory.RemoveItem), new[] { typeof(ItemDrop.ItemData) })]
+        [HarmonyPatch(typeof(Inventory), nameof(Inventory.RemoveItem), new[] { typeof(ItemDrop.ItemData), typeof(int) })]
         [HarmonyPriority(Priority.First)]
-        private static bool RemoveItemPrefix_1(Inventory __instance, ItemDrop.ItemData item) {
-            return ShouldRemoveItem(__instance, item);
-        }
-
-        /// <summary>
-        ///     Patch to check trigger ShouldRemoveItem check and prevent RemoveItem from running if
-        ///     the item was moved during a call to MoveAll and failed to be added to the target
-        ///     container because it was restricted and not the allowed item type.
-        /// </summary>
-        /// <param name="__instance"></param>
-        /// <param name="item"></param>
-        /// <returns></returns>
-        [HarmonyPrefix]
-        [HarmonyPatch(nameof(Inventory.RemoveItem), new[] { typeof(ItemDrop.ItemData), typeof(int) })]
-        [HarmonyPriority(Priority.First)]
-        private static bool RemoveItemPrefix_2(Inventory __instance, ItemDrop.ItemData item) {
+        private static bool RemoveItemPrefix(Inventory __instance, ItemDrop.ItemData item) {
             return ShouldRemoveItem(__instance, item);
         }
 

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -105,7 +105,7 @@ namespace DynamicStoragePiles {
         [HarmonyPrefix]
         [HarmonyPatch(nameof(Inventory.AddItem), new[] { typeof(ItemDrop.ItemData), typeof(int), typeof(int), typeof(int) })]
         [HarmonyPriority(Priority.First)]
-        private static bool AddItemPrefix_2(Inventory __instance, ItemDrop.ItemData item, ref bool __result) {
+        private static bool AddItemPrefix_2(Inventory __instance, ItemDrop.ItemData item, int _, ref bool __result) {
             if (!CanAddItem(__instance, item)) {
                 __result = false;
                 return __result;
@@ -148,7 +148,7 @@ namespace DynamicStoragePiles {
         [HarmonyPrefix]
         [HarmonyPatch(typeof(Inventory), nameof(Inventory.MoveItemToThis), new[] { typeof(Inventory), typeof(ItemDrop.ItemData), typeof(int), typeof(int), typeof(int) })]
         [HarmonyPriority(Priority.First)]
-        private static bool MoveItemToThisPrefix_2(Inventory __instance, Inventory fromInventory, ItemDrop.ItemData item) {
+        private static bool MoveItemToThisPrefix_2(Inventory __instance, Inventory fromInventory, ItemDrop.ItemData item, int _) {
             if (__instance == null || fromInventory == null || item == null) { return false; }
 
             Jotunn.Logger.LogDebug("MoveItemToThisPrefix");

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -32,6 +32,7 @@ namespace DynamicStoragePiles {
         /// <returns></returns>
         private static bool CanAddItem(Inventory inventory, ItemDrop.ItemData item) {
             if (inventory == null || item == null) { return false; }
+
             Jotunn.Logger.LogDebug("CanAddItem");
             Jotunn.Logger.LogDebug($"Add to: {inventory.m_name}");
             Jotunn.Logger.LogDebug($"Item: {item.PrefabName()}");
@@ -43,8 +44,7 @@ namespace DynamicStoragePiles {
                 return true;
             }
 
-            if (IsRestrictedContainer(inventory.m_name, out string allowedItem))
-            {
+            if (IsRestrictedContainer(inventory.m_name, out string allowedItem)) {
                 var result = item.PrefabName() == allowedItem;
                 if (!result) {
                     // Message player that item cannot be placed in container.
@@ -125,9 +125,11 @@ namespace DynamicStoragePiles {
         [HarmonyPriority(Priority.First)]
         private static bool MoveItemToThisPrefix_1(Inventory __instance, Inventory fromInventory, ItemDrop.ItemData item) {
             if (__instance == null || fromInventory == null || item == null) { return false; }
+
             Jotunn.Logger.LogDebug("MoveItemToThisPrefix");
             Jotunn.Logger.LogDebug($"Add to: {__instance.m_name}");
             Jotunn.Logger.LogDebug($"Item: {item.PrefabName()}");
+            
             return CanAddItem(__instance, item);
         }
 
@@ -247,8 +249,7 @@ namespace DynamicStoragePiles {
         /// <returns></returns>
         private static bool ShouldRemoveItem(Inventory __instance, ItemDrop.ItemData item) {
             // early return and block removal since it's null
-            if (__instance == null || item == null)
-            {
+            if (__instance == null || item == null) {
                 return false;
             }
 
@@ -278,7 +279,9 @@ namespace DynamicStoragePiles {
         [HarmonyPatch(nameof(Inventory.Load))]
         private static void LoadPrefix(Inventory __instance) {
             if (__instance == null) { return; }
+
             Jotunn.Logger.LogDebug($"Load prefix: {__instance.m_name}");
+
             _loadingContainer = __instance.m_name;
         }
 

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -102,7 +102,7 @@ namespace DynamicStoragePiles {
         [HarmonyPrefix]
         [HarmonyPatch(nameof(Inventory.AddItem), new[] { typeof(ItemDrop.ItemData), typeof(int), typeof(int), typeof(int) })]
         [HarmonyPriority(Priority.First)]
-        private static bool AddItemPrefix_2(Inventory __instance, ItemDrop.ItemData item, int _, ref bool __result) {
+        private static bool AddItemPrefix_2(Inventory __instance, ItemDrop.ItemData item, int amount, ref bool __result) {
             if (!CanAddItem(__instance, item)) {
                 __result = false;
                 return __result;
@@ -147,7 +147,7 @@ namespace DynamicStoragePiles {
         [HarmonyPrefix]
         [HarmonyPatch(typeof(Inventory), nameof(Inventory.MoveItemToThis), new[] { typeof(Inventory), typeof(ItemDrop.ItemData), typeof(int), typeof(int), typeof(int) })]
         [HarmonyPriority(Priority.First)]
-        private static bool MoveItemToThisPrefix_2(Inventory __instance, Inventory fromInventory, ItemDrop.ItemData item, int _) {
+        private static bool MoveItemToThisPrefix_2(Inventory __instance, Inventory fromInventory, ItemDrop.ItemData item, int amount) {
             if (__instance == null || fromInventory == null || item == null) { return false; }
 
             Jotunn.Logger.LogDebug("MoveItemToThisPrefix");

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -1,16 +1,14 @@
 ﻿using System.Collections.Generic;
 using HarmonyLib;
 
-namespace DynamicStoragePiles
-{
+namespace DynamicStoragePiles {
 
     /// <summary>
     ///     Class to patch Valheim inventory methods so that the specified
     ///     containers can only contain items of a single type.
     /// </summary>
     [HarmonyPatch]
-    internal static class RestrictContainers
-    {
+    internal static class RestrictContainers {
         private static string _loadingContainer;
         private static string _targetContainer;
         private static string _allowedItem;
@@ -24,9 +22,10 @@ namespace DynamicStoragePiles
         /// <param name="inventory"></param>
         /// <param name="item"></param>
         /// <returns></returns>
-        private static bool CanAddItem(Inventory inventory, ItemDrop.ItemData item)
-        {
-            if (inventory == null || item == null) { return false; }
+        private static bool CanAddItem(Inventory inventory, ItemDrop.ItemData item) {
+            if (inventory == null || item == null) {
+                return false;
+            }
 
             Jotunn.Logger.LogDebug("CanAddItem");
             Jotunn.Logger.LogDebug($"Add to: {inventory.m_name}");
@@ -35,22 +34,20 @@ namespace DynamicStoragePiles
             // Return early if this check is being called while loading a container.
             // Don't want to delete "non-allowed" items that were put in the container
             // while the restrictions were disabled.
-            if (inventory.m_name == _loadingContainer)
-            {
+            if (inventory.m_name == _loadingContainer) {
                 return true;
             }
 
-            if (IsRestrictedContainer(inventory.m_name, out string allowedItem))
-            {
+            if (IsRestrictedContainer(inventory.m_name, out string allowedItem)) {
                 var result = item.PrefabName() == allowedItem;
-                if (!result)
-                {
+                if (!result) {
                     // Message player that item cannot be placed in container.
                     var msg = $"{item.m_shared.m_name} cannnot be placed in {inventory.m_name}";
                     Player.m_localPlayer?.Message(MessageHud.MessageType.Center, msg);
                 }
                 return result;
             }
+
             return true;
         }
 
@@ -60,10 +57,8 @@ namespace DynamicStoragePiles
         /// <param name="containerName"></param>
         /// <param name="allowedItem"></param>
         /// <returns></returns>
-        public static bool IsRestrictedContainer(string containerName, out string allowedItem)
-        {
-            if (!DynamicStoragePiles.ShouldRestrictItems)
-            {
+        public static bool IsRestrictedContainer(string containerName, out string allowedItem) {
+            if (!DynamicStoragePiles.ShouldRestrictItems) {
                 allowedItem = null;
                 return false;
             }
@@ -83,10 +78,8 @@ namespace DynamicStoragePiles
         [HarmonyPatch(typeof(Inventory), nameof(Inventory.AddItem), new[] { typeof(ItemDrop.ItemData) })]
         [HarmonyPatch(typeof(Inventory), nameof(Inventory.AddItem), new[] { typeof(ItemDrop.ItemData), typeof(int), typeof(int), typeof(int) })]
         [HarmonyPriority(Priority.First)]
-        private static bool AddItemPrefix(Inventory __instance, ItemDrop.ItemData item, ref bool __result)
-        {
-            if (!CanAddItem(__instance, item))
-            {
+        private static bool AddItemPrefix(Inventory __instance, ItemDrop.ItemData item, ref bool __result) {
+            if (!CanAddItem(__instance, item)) {
                 __result = false;
                 return __result;
             }
@@ -107,8 +100,7 @@ namespace DynamicStoragePiles
         [HarmonyPatch(typeof(Inventory), nameof(Inventory.MoveItemToThis), new[] { typeof(Inventory), typeof(ItemDrop.ItemData) })]
         [HarmonyPatch(typeof(Inventory), nameof(Inventory.MoveItemToThis), new[] { typeof(Inventory), typeof(ItemDrop.ItemData), typeof(int), typeof(int), typeof(int) })]
         [HarmonyPriority(Priority.First)]
-        private static bool MoveItemToThisPrefix(Inventory __instance, Inventory fromInventory, ItemDrop.ItemData item)
-        {
+        private static bool MoveItemToThisPrefix(Inventory __instance, Inventory fromInventory, ItemDrop.ItemData item) {
             if (__instance == null || fromInventory == null || item == null) { return false; }
 
             Jotunn.Logger.LogDebug("MoveItemToThisPrefix");
@@ -132,15 +124,15 @@ namespace DynamicStoragePiles
         [HarmonyPrefix]
         [HarmonyPatch(typeof(Inventory), nameof(Inventory.MoveAll), new[] { typeof(Inventory) })]
         [HarmonyPriority(Priority.First)]
-        private static void MoveAllPrefix(Inventory __instance, Inventory fromInventory)
-        {
-            if (__instance == null || fromInventory == null) { return; }
+        private static void MoveAllPrefix(Inventory __instance, Inventory fromInventory) {
+            if (__instance == null || fromInventory == null) {
+                return;
+            }
 
             Jotunn.Logger.LogDebug("MoveAllPrefix");
             Jotunn.Logger.LogDebug($"Move to: {__instance.m_name}");
 
-            if (IsRestrictedContainer(__instance.m_name, out string allowedItem))
-            {
+            if (IsRestrictedContainer(__instance.m_name, out string allowedItem)) {
                 _targetContainer = __instance.m_name;
                 _allowedItem = allowedItem;
             }
@@ -152,8 +144,7 @@ namespace DynamicStoragePiles
         [HarmonyPrefix]
         [HarmonyPatch(typeof(Inventory), nameof(Inventory.MoveAll), new[] { typeof(Inventory) })]
         [HarmonyPriority(Priority.First)]
-        private static void MoveAllPostfix()
-        {
+        private static void MoveAllPostfix() {
             _targetContainer = null;
             _allowedItem = null;
         }
@@ -170,8 +161,7 @@ namespace DynamicStoragePiles
         [HarmonyPatch(typeof(Inventory), nameof(Inventory.RemoveItem), new[] { typeof(ItemDrop.ItemData) })]
         [HarmonyPatch(typeof(Inventory), nameof(Inventory.RemoveItem), new[] { typeof(ItemDrop.ItemData), typeof(int) })]
         [HarmonyPriority(Priority.First)]
-        private static bool RemoveItemPrefix(Inventory __instance, ItemDrop.ItemData item)
-        {
+        private static bool RemoveItemPrefix(Inventory __instance, ItemDrop.ItemData item) {
             return ShouldRemoveItem(__instance, item);
         }
 
@@ -184,10 +174,9 @@ namespace DynamicStoragePiles
         /// <param name="item"></param>
         /// <returns></returns>
         [HarmonyPrefix]
-        [HarmonyPatch(nameof(Inventory.RemoveOneItem), new[] { typeof(ItemDrop.ItemData) })]
+        [HarmonyPatch(typeof(Inventory), nameof(Inventory.RemoveOneItem), new[] { typeof(ItemDrop.ItemData) })]
         [HarmonyPriority(Priority.First)]
-        private static bool RemoveOneItemPrefix(Inventory __instance, ItemDrop.ItemData item)
-        {
+        private static bool RemoveOneItemPrefix(Inventory __instance, ItemDrop.ItemData item) {
             return ShouldRemoveItem(__instance, item);
         }
 
@@ -199,11 +188,9 @@ namespace DynamicStoragePiles
         /// <param name="__instance"></param>
         /// <param name="item"></param>
         /// <returns></returns>
-        private static bool ShouldRemoveItem(Inventory __instance, ItemDrop.ItemData item)
-        {
+        private static bool ShouldRemoveItem(Inventory __instance, ItemDrop.ItemData item) {
             // early return and block removal since it's null
-            if (__instance == null || item == null)
-            {
+            if (__instance == null || item == null) {
                 return false;
             }
 
@@ -215,8 +202,7 @@ namespace DynamicStoragePiles
             Jotunn.Logger.LogDebug($"Remove from: {__instance.m_name}");
             Jotunn.Logger.LogDebug($"Item: {item.PrefabName()}");
 
-            if (wasAddedToDynamicPile && haveAllowableItem)
-            {
+            if (wasAddedToDynamicPile && haveAllowableItem) {
                 return item.PrefabName() != _allowedItem;
             }
             return true;
@@ -231,9 +217,8 @@ namespace DynamicStoragePiles
         /// </summary>
         /// <param name="__instance"></param>
         [HarmonyPrefix]
-        [HarmonyPatch(nameof(Inventory.Load))]
-        private static void LoadPrefix(Inventory __instance)
-        {
+        [HarmonyPatch(typeof(Inventory), nameof(Inventory.Load))]
+        private static void LoadPrefix(Inventory __instance) {
             if (__instance == null) { return; }
 
             Jotunn.Logger.LogDebug($"Load prefix: {__instance.m_name}");
@@ -246,9 +231,8 @@ namespace DynamicStoragePiles
         /// </summary>
         /// <param name="__instance"></param>
         [HarmonyPostfix]
-        [HarmonyPatch(nameof(Inventory.Load))]
-        private static void LoadPostfix()
-        {
+        [HarmonyPatch(typeof(Inventory), nameof(Inventory.Load))]
+        private static void LoadPostfix() {
             _loadingContainer = null;
         }
     }

--- a/DynamicStoragePiles/RestrictContainers.cs
+++ b/DynamicStoragePiles/RestrictContainers.cs
@@ -40,7 +40,7 @@ namespace DynamicStoragePiles {
             // Return early if this check is being called while loading a container.
             // Don't want to delete "non-allowed" items that were put in the container
             // while the restrictions were disabled.
-            if (!string.IsNullOrEmpty(_loadingContainer) && inventory.m_name == _loadingContainer) {
+            if (inventory.m_name == _loadingContainer) {
                 return true;
             }
 


### PR DESCRIPTION
This PR adds a toggle-able feature that restricts the dynamic containers it adds to only allow placing items of a specific type within the dynamic container. These restrictions can be toggled on/off in-game safely and restrictions are ignored whenever a container is loading from ZDO so that items that may have been placed inside it when it was not restricted are not accidentally deleted when loading the container with restrictions enabled.

I have tested that this feature works as intended in single-player when used alongside QuickStackStore and AzuAutoStore, even if non-allowed item are present in a container both mods do not stack new items to it if the restrictions are enabled. It also works with FastItemTransfer, AzuHoverStats, ContentsWithin, AzuCraftyBoxes, and CraftFromContainers. 

All test were performing using each method of placing items in containers:
- Ctrl + Click
- Holding interact
- Click and move item to place in container

I was not able to test in a multiplayer setting, so I have not tested for possible bugs when multiple players are using the mod or when MultiUserChest is also present.

Most of the changes to code and functionally is contained within the RestrictContainers.cs file and I have done my best to match the existing code conventions within the mod.